### PR TITLE
ENH: Remove orphan/duplicate `github` category

### DIFF
--- a/content/authors/Cameron-Craddock/_index.md
+++ b/content/authors/Cameron-Craddock/_index.md
@@ -5,7 +5,7 @@ title: "Cameron Craddock"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Cameron Craddock"
-github: ccraddock
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Daniel-Marguiles/_index.md
+++ b/content/authors/Daniel-Marguiles/_index.md
@@ -5,7 +5,7 @@ title: "Daniel Marguiles"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Daniel Marguiles"
-github: margulies
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Eneko-Urunuela/_index.md
+++ b/content/authors/Eneko-Urunuela/_index.md
@@ -5,7 +5,7 @@ title: "Eneko Uruñuela"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Eneko Uruñuela"
-github: eurunuela
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Hao-Ting-Wang/_index.md
+++ b/content/authors/Hao-Ting-Wang/_index.md
@@ -5,7 +5,7 @@ title: "Hao-Ting Wang"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Hao-Ting Wang"
-github: htwangtw
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Isil-Poyraz-Bilgin/_index.md
+++ b/content/authors/Isil-Poyraz-Bilgin/_index.md
@@ -5,7 +5,7 @@ title: "Isil Poyraz Bilgin"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Isil Poyraz Bilgin"
-github: complexbrains
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Johanna-Bayer/_index.md
+++ b/content/authors/Johanna-Bayer/_index.md
@@ -5,7 +5,7 @@ title: "Johanna Bayer"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Johanna Bayer"
-github: likeajumprope
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Jon-Haitz-Legarreta-Gorrono/_index.md
+++ b/content/authors/Jon-Haitz-Legarreta-Gorrono/_index.md
@@ -5,7 +5,7 @@ title: "Jon Haitz Legarreta Gorroño"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Jon Haitz Legarreta Gorroño"
-github: jhlegarreta
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Peer-Herholz/_index.md
+++ b/content/authors/Peer-Herholz/_index.md
@@ -5,7 +5,7 @@ title: "Peer Herholz"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Peer Herholz"
-github: PeerHerholz
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Pierre-Bellec/_index.md
+++ b/content/authors/Pierre-Bellec/_index.md
@@ -5,7 +5,7 @@ title: "Pierre Bellec"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Pierre Bellec"
-github: pbellec
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Remi-Gau/_index.md
+++ b/content/authors/Remi-Gau/_index.md
@@ -5,7 +5,7 @@ title: "Rémi Gau"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Remi Gau"
-github: Remi-Gau
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Samuel-Guay/_index.md
+++ b/content/authors/Samuel-Guay/_index.md
@@ -5,7 +5,7 @@ title: "Samuel Guay"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Samuel Guay"
-github: SamGuay
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Stefano-Moia/_index.md
+++ b/content/authors/Stefano-Moia/_index.md
@@ -5,7 +5,7 @@ title: "Stefano Moia"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Stefano Moia"
-github: smoia
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Stephanie-Noble/_index.md
+++ b/content/authors/Stephanie-Noble/_index.md
@@ -5,7 +5,7 @@ title: "Stephanie Noble"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Stephanie Noble"
-github: SNeuroble
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/Valentina-Borghesani/_index.md
+++ b/content/authors/Valentina-Borghesani/_index.md
@@ -5,7 +5,7 @@ title: "Valentina Borghesani"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "Valentina Borghesani"
-github: vborghesani
+
 # Is this the primary user of the site?
 superuser: false
 

--- a/content/authors/firstname-lastname/_index_template.md
+++ b/content/authors/firstname-lastname/_index_template.md
@@ -5,7 +5,7 @@ title: "surname name"
 # Username (this should match the folder name and the name on publications)
 authors:
   - "surname name"
-github: github_username
+
 # Is this the primary user of the site?
 superuser: false
 


### PR DESCRIPTION
Remove orphan/duplicate `github` category from authors' pages.