### PR TITLE
ENH: Use `GitHub` environment variables for repository API URL

### DIFF
--- a/.github/workflows/issue-to-page.yml
+++ b/.github/workflows/issue-to-page.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run script to generate separate pages from issues
       run: |
-        url="https://api.github.com/repos/brainhackorg/global2021/issues?per_page=100"
+        url="https://${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues?per_page=100"
         path="content/project"
         python scripts/issues_to_pages.py $url $path
 


### PR DESCRIPTION
Use `GitHub` environment variables for repository API URL in workflow.

Documentation:
https://docs.github.com/en/actions/learn-github-actions/environment-variables