### PR TITLE
BUG: Provide explicitly the module path in workflow

### DIFF
--- a/.github/workflows/issue-to-page.yml
+++ b/.github/workflows/issue-to-page.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Run script to generate separate pages from issues
       run: |
+        export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
         url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues?per_page=100"
         path="content/project"
         echo "Project issues URL: "


### PR DESCRIPTION
Provide explicitly the module path in the issues to pages workflow: add
the path to the code to the `PYTHONPATH` environment variable.

Fixes:
```
Traceback (most recent call last):
  File "scripts/transform_issues_to_pages.py", line 16, in <module>
    from scripts.issues_to_pages import (
ModuleNotFoundError: No module named 'scripts'
Error: Process completed with exit code 1.
```

Reported at:
https://github.com/brainhackorg/global2021/runs/4237502825?check_suite_focus=true#step:5:21

Fixes #96.