### PR TITLE
BUG: Fix `metaverse` event index markdown syntax

### DIFF
--- a/content/events/metaverse/index.md
+++ b/content/events/metaverse/index.md
@@ -47,7 +47,7 @@ links:
   - icon: mattermost
     icon_pack: custom
     name: Mattermost
-    url:https://mattermost.brainhack.org/brainhack/channels/brainweb
+    url: https://mattermost.brainhack.org/brainhack/channels/brainweb
 
 # Projects (optional).
 #   Associate this post with one or more of your projects.


### PR DESCRIPTION
Fix `metaverse` event index markdown syntax: add a whitespace to
separate key from value.