### PR TITLE
BUG: Fix `toronto` event index markdown syntax

### DIFF
--- a/content/events/toronto/index.md
+++ b/content/events/toronto/index.md
@@ -46,7 +46,7 @@ links:
     name: "@brainhackto"
     url: https://twitter.com/brainhackto
     
-      - icon: mattermost
+  - icon: mattermost
     icon_pack: custom
     name: Mattermost
     url: https://mattermost.brainhack.org/brainhack/channels/brainhack-toronto


### PR DESCRIPTION
Fix `toronto` event index markdown syntax: use the appropriate
indentation.